### PR TITLE
Update intake_demo_UM_DYAMOND3_sims.ipynb

### DIFF
--- a/hk25-UKnode/online/intake_demo_UM_DYAMOND3_sims.ipynb
+++ b/hk25-UKnode/online/intake_demo_UM_DYAMOND3_sims.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat = intake.open_catalog('https://digital-earths-global-hackathon.github.io/catalog/online/main.yaml')"
+    "cat = intake.open_catalog('https://digital-earths-global-hackathon.github.io/catalog/catalog.yaml')['online']"
    ]
   },
   {


### PR DESCRIPTION
Update catalog location.

Previously I was pointing straight to the online catalog in the online dir:
`https://digital-earths-global-hackathon.github.io/catalog/online/main.yaml`. This no longer works due to the catalog being renamed to `catalog.yaml`. Is this the correct way of accessing the online catalog?